### PR TITLE
Support for NVMe in FreeBSD

### DIFF
--- a/plugins/node.d/hddtemp_smartctl
+++ b/plugins/node.d/hddtemp_smartctl
@@ -185,7 +185,7 @@ if ($^O eq 'linux') {
 
 } elsif ($^O eq 'freebsd') {
   opendir(DEV, '/dev');
-  @drives = grep /^(ada?|da)[0-9]+$/, readdir DEV;
+  @drives = grep /^(ada?|da|nvme[0-9]+ns)[0-9]+$/, readdir DEV;
   closedir(DEV);
 } elsif ($^O eq 'solaris') {
   @drives = map { s@.*/@@ ; $_ } glob '/dev/rdsk/c*t*d*s2';


### PR DESCRIPTION
In FreeBSD, NVMe drives are named like "nvme0ns1" in "/dev", so I changed the regex so they could be detected like every others drives.